### PR TITLE
Added AMD support and updated underlying dependency version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ repository = "https://github.com/lovesegfault/cache-size"
 maintenance = { status = "actively-developed" }
 
 [target.'cfg(target_arch = "x86")'.dependencies]
-raw-cpuid = "9.0.0"
+raw-cpuid = "10.2.0"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-raw-cpuid = "9.0.0"
+raw-cpuid = "10.2.0"

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -13,6 +13,7 @@ impl From<CacheType> for raw_cpuid::CacheType {
     }
 }
 
+/// Uses cache parameters to get cache size at a given level with the provided cache type.
 #[inline]
 fn get_cache_parameters_cache_size(cpuid: CpuId, level: u8, cache_type: CacheType) -> Option<usize> {
     let caches = cpuid
@@ -23,6 +24,7 @@ fn get_cache_parameters_cache_size(cpuid: CpuId, level: u8, cache_type: CacheTyp
     Some(cache_size)
 }
 
+/// Uses cache parameters to get cache line size at a given level with the provided cache type.
 #[inline]
 fn get_cache_parameters_cache_line_size(cpuid: CpuId, level: u8, cache_type: CacheType) -> Option<usize>{
     let caches = cpuid
@@ -38,8 +40,12 @@ fn get_cache_parameters_cache_line_size(cpuid: CpuId, level: u8, cache_type: Cac
 /// The only possibilities for this returning `None` are if the system does not support cache
 /// parameters, in which case [`get_cache_parameters()`](raw_cpuid::CpuId::get_cache_parameters) will
 /// fail, or if the selected cache level and/or type does not exist.
+/// 
+/// On an AMD architecture this is computed using tlb info. The values come back in kilobytes,
+/// so they are multiplied by 1024 to give the size in bytes to match the behaviour of
+/// other architectures.
 ///
-/// This is computed as `associativity * line_size * sets`, and if there are multiple caches
+/// On other architectures this is computed as `associativity * line_size * sets`, and if there are multiple caches
 /// available, it returns the size of the **smallest** cache.
 #[inline]
 pub fn cache_size(level: u8, cache_type: CacheType) -> Option<usize> {
@@ -78,7 +84,11 @@ pub fn cache_size(level: u8, cache_type: CacheType) -> Option<usize> {
 /// parameters, in which case [`get_cache_parameters()`](raw_cpuid::CpuId::get_cache_parameters) will
 /// fail, or if the selected cache level and/or type does not exist.
 ///
-/// This is computed from [`coherency_line_size()`](raw_cpuid::CacheParameter::coherency_line_size),
+/// On an AMD architecture this is computed using tlb info. Instruction and data cache line sizes are
+/// available separately for the L1 cache, but only unified is available for L2 and L3 caches.
+/// 
+/// On other x86 architectures this is computed from
+/// [`coherency_line_size()`](raw_cpuid::CacheParameter::coherency_line_size),
 /// and if there are multiple caches available, it returns the size of the **smallest** cache.
 #[inline]
 pub fn cache_line_size(level: u8, cache_type: CacheType) -> Option<usize> {

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -55,13 +55,13 @@ pub fn cache_size(level: u8, cache_type: CacheType) -> Option<usize> {
             },
             2 => {
                 match cache_type {
-                    CacheType::Data => Some(cpuid.get_l2_l3_cache_and_tlb_info()?.l2cache_size() as usize * 1024),
+                    CacheType::Unified => Some(cpuid.get_l2_l3_cache_and_tlb_info()?.l2cache_size() as usize * 1024),
                     _ => None
                 }
             },
             3 => {
                 match cache_type {
-                    CacheType::Data => Some(cpuid.get_l2_l3_cache_and_tlb_info()?.l3cache_size() as usize * 1024),
+                    CacheType::Unified => Some(cpuid.get_l2_l3_cache_and_tlb_info()?.l3cache_size() as usize * 1024),
                     _ => None
                 }
             },


### PR DESCRIPTION
On the AMD architecture, the commands used by default do not work. All of them return none as the CPUs from AMD do not support the features that are used to get the information for Intel CPUs.

Unfortunately it's also Vice versa, so I couldn't just use the mechanism for AMD to get the data for Intel as some of the instructions that work for AMD do not work for intel. This is why there is a if statement to check if the target architecture is AMD, and to otherwise run the code as it functioned before. Let me know if there is anything you need me to update to fit what you think this project should look like.

Thanks in advance for the great work 😄 